### PR TITLE
fix: add return type on getConfigTreeBuilder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Backend/Monitoring&QA

--- a/src/M6Web/Bundle/MonologExtraBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/MonologExtraBundle/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('m6_web_monolog_extra');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
I have some deprecations notice from phpunit when using this bundle on a PHP 8 project.
This PR aim fix them.
```
1x: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "M6Web\Bundle\MonologExtraBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
```